### PR TITLE
Update Electron 2.0.7 -> 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,9 +2995,9 @@
       "dev": true
     },
     "electron": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.7.tgz",
-      "integrity": "sha512-MRrDE6mrp+ZrIBpZM27pxbO2yEDKYfkmc6Ll79BtedMNEZsY4+oblupeDJL6RM6meUIp82KMo63W7fP65Tb89Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.8.tgz",
+      "integrity": "sha512-pbeGFbwijb5V3Xy/KMcwIp59eA9igg2br+7EHbbwQoa3HRDF5JjTrciX7OiscCA52+ze2n4q38S4lXPqRitgIA==",
       "dev": true,
       "requires": {
         "@types/node": "8.10.25",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^1.0.0",
-    "electron": "^2.0.7",
+    "electron": "^2.0.8",
     "electron-reload": "^1.2.5",
     "enzyme": "^3.4.3",
     "enzyme-adapter-react-16": "^1.2.0",


### PR DESCRIPTION
Fixes security vulnerability with Electron, reported here: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15685

A remote code execution vulnerability has been discovered affecting apps with the ability to open nested child windows on Electron versions (3.0.0-beta.6, 2.0.7, 1.8.7, and 1.7.15).

