### PR TITLE
ContentEditable Prototype

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ function createWindow() {
   win.loadFile("./public/index.html");
 
   // Open the DevTools.
-  // win.webContents.openDevTools();
+  win.webContents.openDevTools();
 
   // Create menu
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,25 @@
       "integrity": "sha512-WXvAXaknB0c2cJ7N44e1kUrVu5K90mSfPPaT5XxfuSMxEWva86EYIwxUZM3jNZ2P1CIC9e2z4WJqpAF69PQxeA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.5.tgz",
+      "integrity": "sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react": {
+      "version": "16.4.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.14.tgz",
+      "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.13.tgz",
@@ -2621,6 +2640,12 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
+      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -9328,6 +9353,16 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-contenteditable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.1.0.tgz",
+      "integrity": "sha512-g6ukGK7oNFWKzS2pcDxxfz6jf4o/c56GAmH7oN4kl2z1GWwj+ReesKaxR4d3lNpGccot3cjEj9+dSCCxZl+DRw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "^15.5.4",
+        "fast-deep-equal": "^2.0.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jest": "^23.5.0",
     "mocha": "^5.2.0",
     "prop-types": "^15.6.2",
+    "react-contenteditable": "^3.1.0",
     "react-test-renderer": "^16.4.2",
     "spectron": "^3.8.0",
     "style-loader": "^0.22.1",

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -9,7 +9,8 @@ import ToneBar from "../ToneBar";
 
 class App extends React.Component {
   state = {
-    documentTones: []
+    documentTones: [],
+    sentencesTones: []
   };
 
   render() {
@@ -22,19 +23,20 @@ class App extends React.Component {
   }
 
   handleAnalyzeClick(text) {
-    this.getDocumentTones(text)
+    this.getTones(text)
       .then(tones => {
-        this.setState({ documentTones: tones });
+        this.setState({ documentTones: tones.document_tone.tones });
+        this.setState({ sentencesTones: tones.sentences_tone });
       })
       .catch(() => {
         // noop
       });
   }
 
-  getDocumentTones(text) {
+  getTones(text) {
     return Sentiment.analyze(text)
       .then(results => {
-        return results.document_tone.tones;
+        return results;
       })
       .catch(() => {
         // noop

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -15,7 +15,6 @@ class App extends React.Component {
   render() {
     return (
       <div className="app container">
-        <h1 className="title"> Hello, Relay! </h1>
         <ToneBar tones={this.state.documentTones} />
         <Editor handleAnalyzeClick={this.handleAnalyzeClick.bind(this)} />
       </div>

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -17,7 +17,10 @@ class App extends React.Component {
     return (
       <div className="app container">
         <ToneBar tones={this.state.documentTones} />
-        <Editor handleAnalyzeClick={this.handleAnalyzeClick.bind(this)} />
+        <Editor
+          handleAnalyzeClick={this.handleAnalyzeClick.bind(this)}
+          sentencesTones={this.state.sentencesTones}
+        />
       </div>
     );
   }
@@ -25,8 +28,10 @@ class App extends React.Component {
   handleAnalyzeClick(text) {
     this.getTones(text)
       .then(tones => {
-        this.setState({ documentTones: tones.document_tone.tones });
-        this.setState({ sentencesTones: tones.sentences_tone });
+        this.setState({
+          documentTones: tones.document_tone.tones,
+          sentencesTones: tones.sentences_tone
+        });
       })
       .catch(() => {
         // noop

--- a/src/components/App/index.test.jsx
+++ b/src/components/App/index.test.jsx
@@ -16,17 +16,15 @@ describe("<App />", () => {
   });
 });
 
-describe("this.getDocumentTones", () => {
+describe("this.getTones", () => {
   it("analyzes the given text", async () => {
     const wrapper = shallow(<App />);
 
     Sentiment.analyze = jest.fn(() => {
-      return Promise.resolve({
-        document_tone: { tones: [] }
-      });
+      return Promise.resolve();
     });
 
-    await wrapper.instance().getDocumentTones("foo");
+    await wrapper.instance().getTones("foo");
 
     expect(Sentiment.analyze).toBeCalledWith("foo");
   });
@@ -36,14 +34,16 @@ describe("this.handleAnalyzeClick", () => {
   it("updates state with the result of tone analysis", async () => {
     const wrapper = shallow(<App />);
 
-    jest
-      .spyOn(wrapper.instance(), "getDocumentTones")
-      .mockImplementation(() => {
-        return Promise.resolve(["foo"]);
+    jest.spyOn(wrapper.instance(), "getTones").mockImplementation(() => {
+      return Promise.resolve({
+        document_tone: { tones: ["foo"] },
+        sentences_tone: ["bar"]
       });
+    });
 
     await wrapper.instance().handleAnalyzeClick("Hello, World");
 
     expect(wrapper.state("documentTones")).toEqual(["foo"]);
+    expect(wrapper.state("sentencesTones")).toEqual(["bar"]);
   });
 });

--- a/src/components/App/styles.css
+++ b/src/components/App/styles.css
@@ -8,7 +8,6 @@
   float: left;
   height: auto;
   width: 100%;
-  text-align: center;
 }
 
 .title {

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import nativeUI from "../../nativeUI";
+import ContentEditable from "react-contenteditable";
 import { hot } from "react-hot-loader";
 import "./styles.css";
 
@@ -9,7 +10,7 @@ class Editor extends Component {
   };
 
   handleChange = event => {
-    this.setState({ value: event.currentTarget.value });
+    this.setState({ value: event.target.value });
   };
 
   handleSaveClick = () => {
@@ -39,6 +40,14 @@ class Editor extends Component {
         <button className="button openButton" onClick={this.handleOpenClick}>
           Open
         </button>
+        <ContentEditable
+          html={this.state.value}
+          autoFocus="true"
+          className="editorTextArea"
+          onChange={e => {
+            this.handleChange(e);
+          }}
+        />
       </div>
     );
   }

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -25,14 +25,6 @@ class Editor extends Component {
   render() {
     return (
       <div>
-        <textarea
-          autoFocus="true"
-          className="editorTextArea"
-          onChange={e => {
-            this.handleChange(e);
-          }}
-          value={this.state.value}
-        />
         <button
           className="button analyzeButton"
           onClick={() => {

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -18,7 +18,7 @@ class Editor extends Component {
 
   handleOpenClick = () => {
     nativeUI.promptUserToOpenFileContents().then(fileContents => {
-      this.setState({ value: fileContents });
+      this.setState({ value: fileContents.toString() });
     });
   };
 

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -14,6 +14,7 @@ class Editor extends Component {
   };
 
   componentWillReceiveProps({ sentencesTones }) {
+    console.log(sentencesTones);
     let newValue = this.state.html;
     if (sentencesTones !== undefined) {
       for (let sentenceTone of sentencesTones) {
@@ -23,8 +24,9 @@ class Editor extends Component {
           }</span>`;
           newValue = newValue.replace(sentenceTone.text, annotated);
         }
-        this.setState({ html: newValue });
       }
+      this.setState({ html: newValue });
+      console.log(newValue);
     }
   }
 
@@ -33,7 +35,7 @@ class Editor extends Component {
   };
 
   handleChange = event => {
-    this.setState({ html: this.clearAnnotatedText(event.target.html) });
+    this.setState({ html: this.clearAnnotatedText(event.target.value) });
   };
 
   handleSaveClick = () => {
@@ -53,10 +55,7 @@ class Editor extends Component {
           className="button analyzeButton"
           onClick={() => {
             this.props.handleAnalyzeClick(
-              this.state.html
-                .replace(/<.*?>/g, "")
-                .replace(/[.?!,]/g, "$& ")
-                .trim()
+              this.state.html.replace(/<.*?>/g, " ").trim()
             );
           }}
         >

--- a/src/components/Editor/index.test.jsx
+++ b/src/components/Editor/index.test.jsx
@@ -26,7 +26,7 @@ describe("<Editor />", () => {
 
     expect(wrapper.state("html")).toEqual("");
 
-    textArea.simulate("change", { target: { html: newValue } });
+    textArea.simulate("change", { target: { value: newValue } });
 
     expect(wrapper.state("html")).toEqual(newValue);
   });

--- a/src/components/Editor/index.test.jsx
+++ b/src/components/Editor/index.test.jsx
@@ -26,7 +26,7 @@ describe("<Editor />", () => {
 
     expect(wrapper.state("value")).toEqual("");
 
-    textArea.simulate("change", { currentTarget: { value: newValue } });
+    textArea.simulate("change", { target: { value: newValue } });
 
     expect(wrapper.state("value")).toEqual(newValue);
   });

--- a/src/components/Editor/index.test.jsx
+++ b/src/components/Editor/index.test.jsx
@@ -19,22 +19,22 @@ describe("<Editor />", () => {
     expect(wrapper.exists(".editorTextArea")).toEqual(true);
   });
 
-  it("updates value when textarea is changed", () => {
-    const wrapper = shallow(<Editor />);
+  it("updates html when textarea is changed", () => {
+    const wrapper = shallow(<Editor sentencesTones={[]} />);
     const textArea = wrapper.find(".editorTextArea");
     const newValue = "Hello, World";
 
-    expect(wrapper.state("value")).toEqual("");
+    expect(wrapper.state("html")).toEqual("");
 
-    textArea.simulate("change", { target: { value: newValue } });
+    textArea.simulate("change", { target: { html: newValue } });
 
-    expect(wrapper.state("value")).toEqual(newValue);
+    expect(wrapper.state("html")).toEqual(newValue);
   });
 
-  it("saves value to file when save button is pressed", () => {
+  it("saves html to file when save button is pressed", () => {
     const wrapper = shallow(<Editor />);
     const textareaContent = "Hello World!";
-    wrapper.setState({ value: textareaContent });
+    wrapper.setState({ html: textareaContent });
     const saveButton = wrapper.find(".saveButton");
 
     saveButton.simulate("click");
@@ -44,7 +44,7 @@ describe("<Editor />", () => {
     );
   });
 
-  it("updates the value to a text file's contents when open button is pressed", async () => {
+  it("updates the html to a text file's contents when open button is pressed", async () => {
     const wrapper = shallow(<Editor />);
     const openButton = wrapper.find(".openButton");
     const fileContents = "Hello, World!";
@@ -56,7 +56,7 @@ describe("<Editor />", () => {
     await openButton.simulate("click");
 
     expect(nativeUI.promptUserToOpenFileContents).toBeCalled();
-    expect(wrapper.state("value")).toEqual(fileContents);
+    expect(wrapper.state("html")).toEqual(fileContents);
   });
 
   it("analyzes the document inside the textarea", () => {
@@ -66,7 +66,7 @@ describe("<Editor />", () => {
     const analyzeButton = wrapper.find(".analyzeButton");
 
     const textareaContent = "Hello World!";
-    wrapper.setState({ value: textareaContent });
+    wrapper.setState({ html: textareaContent });
 
     analyzeButton.simulate("click");
 

--- a/src/components/Editor/styles.css
+++ b/src/components/Editor/styles.css
@@ -52,3 +52,31 @@
   background-color: gold;
   color: white;
 }
+
+.analytical {
+  background-color: rgba(65, 105, 225, 0.5);
+}
+
+.anger {
+  background-color: rgba(178, 34, 34, 0.5);
+}
+
+.confident {
+  background-color: rgba(124, 104, 238, 0.5);
+}
+
+.fear {
+  background-color: rgba(34, 139, 34, 0.5);
+}
+
+.joy {
+  background-color: rgba(255, 217, 0, 0.5);
+}
+
+.sadness {
+  background-color: rgba(25, 25, 112, 0.5);
+}
+
+.tentative {
+  background-color: rgba(0, 128, 128, 0.5);
+}

--- a/src/components/Editor/styles.css
+++ b/src/components/Editor/styles.css
@@ -1,26 +1,25 @@
 .editorTextArea {
   float: right;
+  padding: 15px 15px;
   width: 100%;
   min-height: 350px;
   outline: none;
   resize: none;
-  border-top: none;
-  border-right: 1px solid grey;
-  border-left: 1px solid grey;
-  border-bottom: 1px solid grey;
   font-family: Arial, Helvetica, sans-serif;
   font-size: 24px;
   box-sizing: border-box;
 }
 
 .button {
-  padding: 15px 32px;
+  width: 33%;
+  padding: 15px 0;
   text-align: center;
   text-decoration: none;
   font-size: 16px;
   outline: none;
   float: right;
-  margin: 2px 0 0 2px;
+  box-sizing: border-box;
+  margin: 2px 0.11%;
   color: grey;
 }
 

--- a/src/components/ToneBar/styles.css
+++ b/src/components/ToneBar/styles.css
@@ -3,9 +3,6 @@
   width: 100%;
   padding: 20px 0;
   background-color: #e8e8e8;
-  border-top: 1px solid grey;
-  border-right: 1px solid grey;
-  border-left: 1px solid grey;
   box-sizing: border-box;
   text-align: center;
 }

--- a/src/components/ToneBar/styles.css
+++ b/src/components/ToneBar/styles.css
@@ -7,4 +7,5 @@
   border-right: 1px solid grey;
   border-left: 1px solid grey;
   box-sizing: border-box;
+  text-align: center;
 }


### PR DESCRIPTION
Sorry! This code is ugly. 

The "magic" happens in [Editor](https://github.com/Thomascountz/relay/compare/analyze-sentences?expand=1#diff-f025de45baaa27c56f7b70753bba5015). 

It's a bit confusing because I used an external library for `contentEditable`, thinking that it would be more idiomatically "react".

The idea is that we take the user input, which could be any valid html, we strip out the text, send it to the api, get the result, and then loop over the result, replacing the matching sentences with with html that has been annotated based on the analysis results. 

In order to get those results to the `contentEditable`, I passed it in via `props` and used the `componentWillReceiveProps()` hook to update the state, and therefore call `render()` when new props come in.

The flaky string manipulation comes in when a) removing any html generated in the `contentEditable` before sending it to the API, and b) updating the `contentEditable` html with the "annotated" html as a result of the analysis.