### PR TITLE
Report Sentence Analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9389,6 +9389,15 @@
         "react-is": "^16.4.2"
       }
     },
+    "react-textarea-autosize": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.0.4.tgz",
+      "integrity": "sha512-1cC8pFSrIVH92aE+UKxGQ2Gqq43qdIcMscJKScEFeBNemn6gHa+NwKqdXkHxxg5H6uuvW+cPpJPTes6zh90M+A==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "^5.2.0",
     "prop-types": "^15.6.2",
     "react-test-renderer": "^16.4.2",
+    "react-textarea-autosize": "^7.0.4",
     "spectron": "^3.8.0",
     "style-loader": "^0.22.1",
     "webpack": "^4.16.5",

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { hot } from "react-hot-loader";
 import "./styles.css";
 
+import nativeUI from "../../nativeUI";
 import Sentiment from "../../sentiment";
 
 import Editor from "../Editor/index";
@@ -9,6 +10,7 @@ import ToneBar from "../ToneBar";
 
 class App extends React.Component {
   state = {
+    documentText: "",
     documentTones: [],
     sentencesTones: []
   };
@@ -17,13 +19,33 @@ class App extends React.Component {
     return (
       <div className="app container">
         <ToneBar tones={this.state.documentTones} />
-        <Editor handleAnalyzeClick={this.handleAnalyzeClick.bind(this)} />
+        <Editor
+          value={this.state.documentText}
+          handleChange={this.handleChange.bind(this)}
+          handleSaveClick={this.handleSaveClick.bind(this)}
+          handleOpenClick={this.handleOpenClick.bind(this)}
+          handleAnalyzeClick={this.handleAnalyzeClick.bind(this)}
+        />
       </div>
     );
   }
 
-  handleAnalyzeClick(text) {
-    return Sentiment.analyze(text)
+  handleChange(event) {
+    this.setState({ documentText: event.currentTarget.value });
+  }
+
+  handleSaveClick() {
+    nativeUI.promptUserToSaveContentToFile(this.state.documentText);
+  }
+
+  handleOpenClick() {
+    nativeUI.promptUserToOpenFileContents().then(fileContents => {
+      this.setState({ documentText: fileContents });
+    });
+  }
+
+  handleAnalyzeClick() {
+    return Sentiment.analyze(this.state.documentText)
       .then(result => {
         return result;
       })

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -7,6 +7,7 @@ import Sentiment from "../../sentiment";
 
 import Editor from "../Editor/index";
 import ToneBar from "../ToneBar";
+import ToneMat from "../ToneMat";
 
 class App extends React.Component {
   state = {
@@ -20,12 +21,14 @@ class App extends React.Component {
       <div className="app container">
         <ToneBar tones={this.state.documentTones} />
         <Editor
+          className="editor"
           value={this.state.documentText}
           handleChange={this.handleChange.bind(this)}
           handleSaveClick={this.handleSaveClick.bind(this)}
           handleOpenClick={this.handleOpenClick.bind(this)}
           handleAnalyzeClick={this.handleAnalyzeClick.bind(this)}
         />
+        <ToneMat className="toneMat" value={this.state.documentText} />
       </div>
     );
   }

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -9,7 +9,8 @@ import ToneBar from "../ToneBar";
 
 class App extends React.Component {
   state = {
-    documentTones: []
+    documentTones: [],
+    sentencesTones: []
   };
 
   render() {
@@ -22,19 +23,15 @@ class App extends React.Component {
   }
 
   handleAnalyzeClick(text) {
-    this.getDocumentTones(text)
-      .then(tones => {
-        this.setState({ documentTones: tones });
-      })
-      .catch(() => {
-        // noop
-      });
-  }
-
-  getDocumentTones(text) {
     return Sentiment.analyze(text)
-      .then(results => {
-        return results.document_tone.tones;
+      .then(result => {
+        return result;
+      })
+      .then(result => {
+        this.setState({
+          documentTones: result.document_tone.tones,
+          sentencesTones: result.sentences_tones
+        });
       })
       .catch(() => {
         // noop

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -15,7 +15,6 @@ class App extends React.Component {
   render() {
     return (
       <div className="app container">
-        <h1 className="title"> Hello, Relay! </h1>
         <ToneBar tones={this.state.documentTones} />
         <Editor handleAnalyzeClick={this.handleAnalyzeClick.bind(this)} />
       </div>

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -28,7 +28,11 @@ class App extends React.Component {
           handleOpenClick={this.handleOpenClick.bind(this)}
           handleAnalyzeClick={this.handleAnalyzeClick.bind(this)}
         />
-        <ToneMat className="toneMat" value={this.state.documentText} />
+        <ToneMat
+          className="toneMat"
+          value={this.state.documentText}
+          sentencesTones={this.state.sentencesTones}
+        />
       </div>
     );
   }
@@ -43,7 +47,7 @@ class App extends React.Component {
 
   handleOpenClick() {
     nativeUI.promptUserToOpenFileContents().then(fileContents => {
-      this.setState({ documentText: fileContents });
+      this.setState({ documentText: fileContents.toString() });
     });
   }
 
@@ -55,7 +59,7 @@ class App extends React.Component {
       .then(result => {
         this.setState({
           documentTones: result.document_tone.tones,
-          sentencesTones: result.sentences_tones
+          sentencesTones: result.sentences_tone
         });
       })
       .catch(() => {

--- a/src/components/App/index.test.jsx
+++ b/src/components/App/index.test.jsx
@@ -68,7 +68,7 @@ describe("handleAnalyzeClick", () => {
     Sentiment.analyze = jest.fn(() => {
       return Promise.resolve({
         document_tone: { tones: ["foo"] },
-        sentences_tones: ["bar"]
+        sentences_tone: ["bar"]
       });
     });
 

--- a/src/components/App/index.test.jsx
+++ b/src/components/App/index.test.jsx
@@ -16,34 +16,20 @@ describe("<App />", () => {
   });
 });
 
-describe("this.getDocumentTones", () => {
-  it("analyzes the given text", async () => {
-    const wrapper = shallow(<App />);
-
-    Sentiment.analyze = jest.fn(() => {
-      return Promise.resolve({
-        document_tone: { tones: [] }
-      });
-    });
-
-    await wrapper.instance().getDocumentTones("foo");
-
-    expect(Sentiment.analyze).toBeCalledWith("foo");
-  });
-});
-
 describe("this.handleAnalyzeClick", () => {
   it("updates state with the result of tone analysis", async () => {
     const wrapper = shallow(<App />);
 
-    jest
-      .spyOn(wrapper.instance(), "getDocumentTones")
-      .mockImplementation(() => {
-        return Promise.resolve(["foo"]);
+    Sentiment.analyze = jest.fn(() => {
+      return Promise.resolve({
+        document_tone: { tones: ["foo"] },
+        sentences_tones: ["bar"]
       });
+    });
 
     await wrapper.instance().handleAnalyzeClick("Hello, World");
 
     expect(wrapper.state("documentTones")).toEqual(["foo"]);
+    expect(wrapper.state("sentencesTones")).toEqual(["bar"]);
   });
 });

--- a/src/components/App/styles.css
+++ b/src/components/App/styles.css
@@ -8,7 +8,6 @@
   float: left;
   height: auto;
   width: 100%;
-  text-align: center;
 }
 
 .title {

--- a/src/components/App/styles.css
+++ b/src/components/App/styles.css
@@ -6,10 +6,6 @@
 .container {
   margin: 0px auto;
   float: left;
-  height: auto;
+  min-height: 350px;
   width: 100%;
-}
-
-.title {
-  text-align: left;
 }

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import { hot } from "react-hot-loader";
 import "./styles.css";
 
+import Textarea from "react-textarea-autosize";
+
 const Editor = props => {
   return (
     <div>
@@ -17,7 +19,7 @@ const Editor = props => {
       <button className="button openButton" onClick={props.handleOpenClick}>
         Open
       </button>
-      <textarea
+      <Textarea
         autoFocus="true"
         className="editorTextArea"
         onChange={e => {

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -1,55 +1,32 @@
-import React, { Component } from "react";
-import nativeUI from "../../nativeUI";
+import React from "react";
 import { hot } from "react-hot-loader";
 import "./styles.css";
 
-class Editor extends Component {
-  state = {
-    value: ""
-  };
-
-  handleChange = event => {
-    this.setState({ value: event.currentTarget.value });
-  };
-
-  handleSaveClick = () => {
-    nativeUI.promptUserToSaveContentToFile(this.state.value);
-  };
-
-  handleOpenClick = () => {
-    nativeUI.promptUserToOpenFileContents().then(fileContents => {
-      this.setState({ value: fileContents });
-    });
-  };
-
-  render() {
-    return (
-      <div>
-        <button
-          className="button analyzeButton"
-          onClick={() => {
-            this.props.handleAnalyzeClick(this.state.value);
-          }}
-        >
-          Analyze
-        </button>
-        <button className="button saveButton" onClick={this.handleSaveClick}>
-          Save
-        </button>
-        <button className="button openButton" onClick={this.handleOpenClick}>
-          Open
-        </button>
-        <textarea
-          autoFocus="true"
-          className="editorTextArea"
-          onChange={e => {
-            this.handleChange(e);
-          }}
-          value={this.state.value}
-        />
-      </div>
-    );
-  }
-}
+const Editor = props => {
+  return (
+    <div>
+      <button
+        className="button analyzeButton"
+        onClick={props.handleAnalyzeClick}
+      >
+        Analyze
+      </button>
+      <button className="button saveButton" onClick={props.handleSaveClick}>
+        Save
+      </button>
+      <button className="button openButton" onClick={props.handleOpenClick}>
+        Open
+      </button>
+      <textarea
+        autoFocus="true"
+        className="editorTextArea"
+        onChange={e => {
+          props.handleChange(e);
+        }}
+        value={props.value}
+      />
+    </div>
+  );
+};
 
 export default hot(module)(Editor);

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -25,14 +25,6 @@ class Editor extends Component {
   render() {
     return (
       <div>
-        <textarea
-          autoFocus="true"
-          className="editorTextArea"
-          onChange={e => {
-            this.handleChange(e);
-          }}
-          value={this.state.value}
-        />
         <button
           className="button analyzeButton"
           onClick={() => {
@@ -47,6 +39,14 @@ class Editor extends Component {
         <button className="button openButton" onClick={this.handleOpenClick}>
           Open
         </button>
+        <textarea
+          autoFocus="true"
+          className="editorTextArea"
+          onChange={e => {
+            this.handleChange(e);
+          }}
+          value={this.state.value}
+        />
       </div>
     );
   }

--- a/src/components/Editor/index.test.jsx
+++ b/src/components/Editor/index.test.jsx
@@ -4,9 +4,6 @@ import Enzyme, { shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 Enzyme.configure({ adapter: new Adapter() });
 
-import nativeUI from "../../nativeUI";
-jest.mock("../../nativeUI");
-
 import Editor from "./index";
 
 describe("<Editor />", () => {
@@ -20,43 +17,35 @@ describe("<Editor />", () => {
   });
 
   it("updates value when textarea is changed", () => {
-    const wrapper = shallow(<Editor />);
-    const textArea = wrapper.find(".editorTextArea");
+    const handleChange = jest.fn();
+    const wrapper = shallow(<Editor value="" handleChange={handleChange} />);
     const newValue = "Hello, World";
+    const event = { currentTarget: { value: newValue } };
+    const textArea = wrapper.find(".editorTextArea");
 
-    expect(wrapper.state("value")).toEqual("");
+    textArea.simulate("change", event);
 
-    textArea.simulate("change", { currentTarget: { value: newValue } });
-
-    expect(wrapper.state("value")).toEqual(newValue);
+    expect(handleChange).toBeCalledWith(event);
   });
 
   it("saves value to file when save button is pressed", () => {
-    const wrapper = shallow(<Editor />);
-    const textareaContent = "Hello World!";
-    wrapper.setState({ value: textareaContent });
+    const handleSaveClick = jest.fn();
+    const wrapper = shallow(<Editor handleSaveClick={handleSaveClick} />);
     const saveButton = wrapper.find(".saveButton");
 
     saveButton.simulate("click");
 
-    expect(nativeUI.promptUserToSaveContentToFile).toBeCalledWith(
-      textareaContent
-    );
+    expect(handleSaveClick).toBeCalled();
   });
 
-  it("updates the value to a text file's contents when open button is pressed", async () => {
-    const wrapper = shallow(<Editor />);
+  it("opens a file when the button is pressed", () => {
+    const handleOpenClick = jest.fn();
+    const wrapper = shallow(<Editor handleOpenClick={handleOpenClick} />);
     const openButton = wrapper.find(".openButton");
-    const fileContents = "Hello, World!";
 
-    nativeUI.promptUserToOpenFileContents = jest.fn(() => {
-      return Promise.resolve(fileContents);
-    });
+    openButton.simulate("click");
 
-    await openButton.simulate("click");
-
-    expect(nativeUI.promptUserToOpenFileContents).toBeCalled();
-    expect(wrapper.state("value")).toEqual(fileContents);
+    expect(handleOpenClick).toBeCalled();
   });
 
   it("analyzes the document inside the textarea", () => {
@@ -65,11 +54,8 @@ describe("<Editor />", () => {
 
     const analyzeButton = wrapper.find(".analyzeButton");
 
-    const textareaContent = "Hello World!";
-    wrapper.setState({ value: textareaContent });
-
     analyzeButton.simulate("click");
 
-    expect(handleAnalyzeClick).toBeCalledWith(textareaContent);
+    expect(handleAnalyzeClick).toBeCalled();
   });
 });

--- a/src/components/Editor/styles.css
+++ b/src/components/Editor/styles.css
@@ -4,23 +4,20 @@
   min-height: 350px;
   outline: none;
   resize: none;
-  border-top: none;
-  border-right: 1px solid grey;
-  border-left: 1px solid grey;
-  border-bottom: 1px solid grey;
   font-family: Arial, Helvetica, sans-serif;
   font-size: 24px;
   box-sizing: border-box;
 }
 
 .button {
-  padding: 15px 32px;
+  width: 33.1%;
+  padding: 15px 0;
   text-align: center;
   text-decoration: none;
   font-size: 16px;
   outline: none;
   float: right;
-  margin: 2px 0 0 2px;
+  margin: 2px 1px;
   color: grey;
 }
 

--- a/src/components/Editor/styles.css
+++ b/src/components/Editor/styles.css
@@ -1,12 +1,13 @@
 .editorTextArea {
-  float: right;
-  width: 100%;
-  min-height: 350px;
+  float: left;
+  overflow: hidden;
+  width: 50%;
   outline: none;
   resize: none;
   font-family: Arial, Helvetica, sans-serif;
   font-size: 24px;
   box-sizing: border-box;
+  border: none;
 }
 
 .button {

--- a/src/components/ToneBar/styles.css
+++ b/src/components/ToneBar/styles.css
@@ -3,9 +3,6 @@
   width: 100%;
   padding: 20px 0;
   background-color: #e8e8e8;
-  border-top: 1px solid grey;
-  border-right: 1px solid grey;
-  border-left: 1px solid grey;
   box-sizing: border-box;
   text-align: center;
 }

--- a/src/components/ToneBar/styles.css
+++ b/src/components/ToneBar/styles.css
@@ -7,4 +7,5 @@
   border-right: 1px solid grey;
   border-left: 1px solid grey;
   box-sizing: border-box;
+  text-align: center;
 }

--- a/src/components/ToneMat/index.jsx
+++ b/src/components/ToneMat/index.jsx
@@ -3,7 +3,70 @@ import { hot } from "react-hot-loader";
 import "./styles.css";
 
 const ToneMat = props => {
-  return <div className="toneMat">{props.value}</div>;
+  return (
+    <div
+      className="toneMat"
+      dangerouslySetInnerHTML={{
+        __html: getAnnotatedSentences(props.value, props.sentencesTones)
+      }}
+    />
+  );
+};
+
+const getAnnotatedSentences = (sentences, sentencesTones) => {
+  let annotatedSentences = clearHTML(sentences);
+
+  if (sentenceTonesExist(sentencesTones)) {
+    for (let sentenceTone of sentencesTones) {
+      if (tonesExistForThisSentence(sentenceTone)) {
+        let sentenceText = getSentenceText(sentenceTone);
+        let toneID = getFirstToneID(sentenceTone);
+
+        annotatedSentences = annotatedSentences.replace(
+          sentenceText,
+          annotateString(sentenceText, toneID)
+        );
+      }
+    }
+  }
+
+  return annotatedSentences;
+};
+
+const clearHTML = content => {
+  return escapeHTML(clearPreviousAnnotations(content));
+};
+
+const clearPreviousAnnotations = content => {
+  return content.replace(/<\/*span[^>]*>/g, "");
+};
+
+const escapeHTML = content => {
+  return content
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+};
+
+const sentenceTonesExist = sentenceTones => {
+  return !!sentenceTones;
+};
+
+const tonesExistForThisSentence = sentenceTone => {
+  return !!sentenceTone.tones[0];
+};
+
+const getFirstToneID = sentenceTone => {
+  return sentenceTone.tones[0].tone_id;
+};
+
+const getSentenceText = sentenceTone => {
+  return sentenceTone.text;
+};
+
+const annotateString = (string, className) => {
+  return `<span class="${className}">${string}</span>`;
 };
 
 export default hot(module)(ToneMat);

--- a/src/components/ToneMat/index.jsx
+++ b/src/components/ToneMat/index.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { hot } from "react-hot-loader";
+import "./styles.css";
+
+const ToneMat = props => {
+  return <div className="toneMat">{props.value}</div>;
+};
+
+export default hot(module)(ToneMat);

--- a/src/components/ToneMat/index.test.jsx
+++ b/src/components/ToneMat/index.test.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+import Enzyme, { render } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+
+import ToneMat from "./index";
+
+describe("ToneMat", () => {
+  it("renders the documentText", () => {
+    const text = "Hello, World";
+    const wrapper = render(<ToneMat value={text} sentencesTones={[]} />);
+    expect(wrapper.text()).toEqual(text);
+  });
+
+  it("renders documentText that is not present in sentencesTones", () => {
+    const text = "I love being here!I hate everything about this day!";
+    const sentencesTones = [
+      {
+        sentence_id: 0,
+        text: "I love being here!",
+        tones: []
+      }
+    ];
+
+    const wrapper = render(
+      <ToneMat value={text} sentencesTones={sentencesTones} />
+    );
+
+    expect(wrapper.text()).toContain(text);
+  });
+
+  it("annotates sentences with the class of most prominent tone", () => {
+    const text = "I hate everything about this day!";
+    const sentencesTones = [
+      {
+        sentence_id: 0,
+        text: "I hate everything about this day!",
+        tones: [
+          { score: 0.819448, tone_id: "anger", tone_name: "Anger" },
+          { score: 0.75152, tone_id: "tentative", tone_name: "Tentative" }
+        ]
+      }
+    ];
+
+    const wrapper = render(
+      <ToneMat value={text} sentencesTones={sentencesTones} />
+    );
+
+    expect(wrapper.find(".anger").length).toEqual(1);
+    expect(wrapper.find(".tenative").length).toEqual(0);
+  });
+
+  it("does not annotate sentences that do not have tones", () => {
+    const text = "I love being here!I hate everything about this day!";
+    const sentencesTones = [
+      {
+        sentence_id: 0,
+        text: "I love being here!",
+        tones: []
+      },
+      {
+        sentence_id: 1,
+        text: "I hate everything about this day!",
+        tones: [{ score: 0.819448, tone_id: "anger", tone_name: "Anger" }]
+      }
+    ];
+
+    const wrapper = render(
+      <ToneMat value={text} sentencesTones={sentencesTones} />
+    );
+
+    expect(wrapper.find("span").length).toEqual(1);
+    expect(wrapper.text()).toContain(text);
+  });
+});
+
+it("maintains formatting", () => {
+  const text = "I love being here!/n/n  I hate everything about this day!";
+  const sentencesTones = [
+    {
+      sentence_id: 0,
+      text: "I love being here!",
+      tones: []
+    },
+    {
+      sentence_id: 1,
+      text: "I hate everything about this day!",
+      tones: [{ score: 0.819448, tone_id: "anger", tone_name: "Anger" }]
+    }
+  ];
+
+  const wrapper = render(
+    <ToneMat value={text} sentencesTones={sentencesTones} />
+  );
+
+  expect(wrapper.text()).toContain(text);
+});

--- a/src/components/ToneMat/styles.css
+++ b/src/components/ToneMat/styles.css
@@ -1,0 +1,9 @@
+.toneMat {
+  float: right;
+  width: 50%;
+  height: 100%;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 24px;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+}

--- a/src/components/ToneMat/styles.css
+++ b/src/components/ToneMat/styles.css
@@ -7,3 +7,31 @@
   box-sizing: border-box;
   white-space: pre-wrap;
 }
+
+.analytical {
+  background-color: rgba(65, 105, 225, 0.5);
+}
+
+.anger {
+  background-color: rgba(178, 34, 34, 0.5);
+}
+
+.confident {
+  background-color: rgba(124, 104, 238, 0.5);
+}
+
+.fear {
+  background-color: rgba(34, 139, 34, 0.5);
+}
+
+.joy {
+  background-color: rgba(255, 217, 0, 0.5);
+}
+
+.sadness {
+  background-color: rgba(25, 25, 112, 0.5);
+}
+
+.tentative {
+  background-color: rgba(0, 128, 128, 0.5);
+}


### PR DESCRIPTION
<img width="1439" alt="screen shot 2018-09-20 at 3 11 09 pm" src="https://user-images.githubusercontent.com/19786848/45841352-8c2c9780-bce7-11e8-96d4-32531c0eb7d8.png">

Closes #24 Closes #12 

## Description 
The PR introduces the `ToneMat`, which is an area of the editor that mirrors the user's input area. When you enter text into the textarea and press "Analyze," the mirrored text in the `ToneMat` is highlighted to indicate the predominate tone of that sentence. The tones are: 

Analytical `rgba(65, 105, 225, 0.5)`
 Anger `rgba(178, 34, 34, 0.5)`
 Confident  `rgba(124, 104, 238, 0.5)`
 Fear `rgba(34, 139, 34, 0.5)`
 Joy `rgba(255, 217, 0, 0.5)`
 Sadness `rgba(25, 25, 112, 0.5)`
 Tentative `rgba(0, 128, 128, 0.5)`

## Other Changes

The `Editor` is now a "dumb" component, a.k.a. it is a stateless controlled component; all of the functionality/state has moved up to `App`. This allows for the sharing of state between the `Editor` and `ToneMat`, and will allow of the "Save", "Open", and "Analyze" buttons to move to their own component. Lastly, this will allow for all data to flow in and out of the system through a single source-of-truth.

## In Depth
`ToneMat` goes against some React conventions by utilizing the aptly-mentioned `dangerouslySetInnerHTML()`, which does exactly as it says. This was the easiest and most maintainable way to dynamically create "annotated" elements. 

`ToneMat.props.value` comes in as a `String`, and is ultimately rendered as a `String`. In order to dynamically/programmatically annotate a `String`, we can either use string parsing techniques and set the `innerHTML` of the `ToneMat`, as is the case here, or we can convert the string into another object that React likes better.

If we instead turn the string into a series of JSX `<span>` components, we can rely on React to safely handle the content and manipulate it as we can expect. However, conditionally turning some of the `ToneMat.props.value` `String` into `<span>`s, based on the contents of the `SentencesTones` object, (returned for the analysis), proved to be too restrictive in terms of keeping punctuation and whitespace.

It turns out that the API parses the incoming string and determines what's a sentence and what isn't based on undocumented/unpublished rules. So when we get a result from the API, we can't be sure that it contains the same structural format as we sent. This wouldn't be a problem if we were reporting the results in, say, a spreadsheet, but we want to maintain the formatting that the user has entered.

This lead to the use of `dangerouslySetInnerHTML()`, and the need to `escapeHTML()` to megerly protect against XSS, but mostly, unexpected UI bugs.

## Known Issues
#31 - Only first instance of repeated sentence is highlighted, multiple times