### PR TITLE
Update ToneBar UI

### DIFF
--- a/src/components/ToneSignal/index.jsx
+++ b/src/components/ToneSignal/index.jsx
@@ -5,18 +5,16 @@ import "./styles.css";
 const ToneSignal = props => {
   return (
     <div className="tone-signal">
-      <div className="tone">
-        <span className={"dot " + getDotClassFor(props.name, props.score)} />
-        {renderName(props.name)} {renderScore(props.score)}
+      <div className={"dot " + getDotClassFor(props.name)}>
+        {renderScore(props.score)}
       </div>
+      <div>{renderName(props.name)}</div>
     </div>
   );
 };
 
-const getDotClassFor = (name, score) => {
-  if (!(score == undefined)) {
-    return (name + "-dot").toLowerCase();
-  }
+const getDotClassFor = name => {
+  return (name + "-dot").toLowerCase();
 };
 
 const renderName = name => {

--- a/src/components/ToneSignal/index.test.jsx
+++ b/src/components/ToneSignal/index.test.jsx
@@ -11,7 +11,7 @@ it("renders a toneSignal with a given name", () => {
   const renderedName = "Joy";
   const wrapper = shallow(<ToneSignal name={name} />);
 
-  const toneSignalName = wrapper.find(".tone");
+  const toneSignalName = wrapper.find(".tone-signal");
 
   expect(toneSignalName.text()).toContain(renderedName);
 });
@@ -21,7 +21,7 @@ it("renders a toneSignal with a default score of zero", () => {
   const renderedScore = "0";
   const wrapper = shallow(<ToneSignal name={name} />);
 
-  const toneSignalName = wrapper.find(".tone");
+  const toneSignalName = wrapper.find(".tone-signal");
 
   expect(toneSignalName.text()).toContain(renderedScore);
 });
@@ -31,12 +31,12 @@ it("renders a toneSignal with a given score", () => {
   const score = "6.0";
   const wrapper = shallow(<ToneSignal name={name} score={score} />);
 
-  const toneSignalName = wrapper.find(".tone");
+  const toneSignalName = wrapper.find(".tone-signal");
 
   expect(toneSignalName.text()).toContain(score);
 });
 
-it("adds specific class to dot for a given tone name when score is defined", () => {
+it("adds specific class to dot for a given tone name", () => {
   const name = "joy";
   const score = "6.0";
   const wrapper = shallow(<ToneSignal name={name} score={score} />);
@@ -44,14 +44,4 @@ it("adds specific class to dot for a given tone name when score is defined", () 
   const toneSignaldot = wrapper.find(".dot");
 
   expect(toneSignaldot.hasClass("joy-dot")).toEqual(true);
-});
-
-it("does not add a specific class to dot for a given tone name when score is undefined", () => {
-  const name = "joy";
-  const score = undefined;
-  const wrapper = shallow(<ToneSignal name={name} score={score} />);
-
-  const toneSignaldot = wrapper.find(".dot");
-
-  expect(toneSignaldot.hasClass("joy-dot")).toEqual(false);
 });

--- a/src/components/ToneSignal/styles.css
+++ b/src/components/ToneSignal/styles.css
@@ -1,44 +1,45 @@
 .tone-signal {
+  text-align: center;
   padding: 0 5px;
-  margin: 0 5px;
+  margin: 0 30px;
   font-weight: bold;
   display: inline-block;
   box-sizing: border-box;
 }
 
 .dot {
-  float: left;
-  height: 20px;
-  width: 20px;
-  background-color: grey;
+  margin: 0 auto 5px auto;
+  line-height: 50px;
+  font-size: 25px;
+  height: 50px;
+  width: 50px;
   border-radius: 50%;
-  margin-right: 10px;
 }
 
 .analytical-dot {
-  background-color: royalblue;
+  background-color: rgba(65, 105, 225, 0.5);
 }
 
 .anger-dot {
-  background-color: firebrick;
+  background-color: rgba(178, 34, 34, 0.5);
 }
 
 .confident-dot {
-  background-color: mediumslateblue;
+  background-color: rgba(124, 104, 238, 0.5);
 }
 
 .fear-dot {
-  background-color: forestgreen;
+  background-color: rgba(34, 139, 34, 0.5);
 }
 
 .joy-dot {
-  background-color: gold;
+  background-color: rgba(255, 217, 0, 0.5);
 }
 
 .sadness-dot {
-  background-color: midnightblue;
+  background-color: rgba(25, 25, 112, 0.5);
 }
 
 .tentative-dot {
-  background-color: teal;
+  background-color: rgba(0, 128, 128, 0.5);
 }


### PR DESCRIPTION
closes #39 

# Description
<img width="972" alt="screen shot 2018-09-24 at 12 01 46 pm" src="https://user-images.githubusercontent.com/19786848/45964038-a5d52400-bff2-11e8-9a43-37bc42355fa1.png">

This new UI allows the user to have a constant legend for the highlighting colors they'll see in the editor. Originally, if the document hadn't scored high enough on a tone to register a score, the dot would be greyed-out. However, one of the grey-ed out tones might exist for a sentence. If this were the case, the user would not have a way to map the color of the highlighting to the name of a tone.