### PR TITLE
Send POST requests to API

### DIFF
--- a/src/sentiment.js
+++ b/src/sentiment.js
@@ -5,7 +5,7 @@ const SENTIMENT_ANALYSIS_ENDPOINT =
 
 const analyze = text => {
   return axios
-    .get(constructURI(text))
+    .post(SENTIMENT_ANALYSIS_ENDPOINT, build_body(text))
     .then(result => {
       return result.data;
     })
@@ -14,8 +14,8 @@ const analyze = text => {
     });
 };
 
-const constructURI = text => {
-  return encodeURI(SENTIMENT_ANALYSIS_ENDPOINT + "?text=" + text);
+const build_body = text => {
+  return { text: text };
 };
 
 module.exports = {

--- a/src/sentiment.test.js
+++ b/src/sentiment.test.js
@@ -7,23 +7,22 @@ describe("analyze", () => {
   it("sends a get request with encoded text", async () => {
     const text = "lorem ipsum dolor sit amet";
 
-    axios.get = jest.fn(() => {
+    axios.post = jest.fn(() => {
       return Promise.resolve("Result");
     });
 
     await sentiment.analyze(text);
 
-    expect(axios.get).toBeCalledWith(
-      sentiment.SENTIMENT_ANALYSIS_ENDPOINT +
-        "?text=lorem%20ipsum%20dolor%20sit%20amet"
-    );
+    expect(axios.post).toBeCalledWith(sentiment.SENTIMENT_ANALYSIS_ENDPOINT, {
+      text: text
+    });
   });
 
   it("returns the result of successful requests", () => {
     const text = "lorem ipsum dolor sit amet";
     const expectedResult = "Result";
 
-    axios.get = jest.fn(() => {
+    axios.post = jest.fn(() => {
       return Promise.resolve({ data: expectedResult });
     });
 


### PR DESCRIPTION
closes #40 

# Description
This PR updates the interaction with the relay-service API. Request are now sent as POST requests, which removes the arbitrary length limit caused by sending GET requests.